### PR TITLE
Typo - Brackets

### DIFF
--- a/Aula 9 - Potencia e energia dos sinais/potencia e energia dos sinais.ipynb
+++ b/Aula 9 - Potencia e energia dos sinais/potencia e energia dos sinais.ipynb
@@ -31,10 +31,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "(# importar as bibliotecas necessárias\n",
+    "# importar as bibliotecas necessárias\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "plt.rcParams.update({'font.size': 14}))"
+    "plt.rcParams.update({'font.size': 14})"
    ]
   },
   {


### PR DESCRIPTION
Parentheses inserted incorrectly in the first cell